### PR TITLE
Add `Raw` attribute to `QueryOption` to bypass (most) URL Encoding

### DIFF
--- a/request.go
+++ b/request.go
@@ -62,11 +62,8 @@ func (c *Client) request(method, path string, v interface{}, queryOptions QueryO
 
 		query := make(map[string][]string)
 		if queryOptions != nil {
-			for key, val := range queryOptions.toMap() {
-				query[key] = val
-			}
+			query = queryOptions.toMap(true)
 		}
-
 		if c.APIKey != "" {
 			query["apikey"] = []string{c.APIKey}
 		} else if c.Token != "" {

--- a/util.go
+++ b/util.go
@@ -6,23 +6,11 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"net/url"
 	"reflect"
 	"strings"
 
 	"github.com/resin-io/pinejs-client-go/Godeps/_workspace/src/github.com/bitly/go-simplejson"
 )
-
-// oDataEncodeVals URL Encode values and separate with commas.
-func oDataEncodeVals(strs []string) string {
-	encoded := make([]string, len(strs))
-
-	for i, str := range strs {
-		encoded[i] = strings.Replace(url.QueryEscape(str), "+", "%20", -1)
-	}
-
-	return strings.Join(encoded, ",")
-}
 
 // encodeQuery encodes query values, working around a net/url issue whereby keys
 // get encoded as well as values. We only want values encoded, otherwise OData
@@ -38,7 +26,7 @@ func encodeQuery(query map[string][]string) string {
 			continue
 		}
 
-		tuple := key + "=" + oDataEncodeVals(vals)
+		tuple := key + "=" + strings.Replace(strings.Join(vals, ","), " ", "%20", -1)
 		tuples = append(tuples, tuple)
 	}
 


### PR DESCRIPTION
The first commit is very much a "make it work" solution, not necessarily a mergeable fix. With the previous solution in place filters [like this](https://github.com/resin-io-playground/sshproxy/blob/master/resin/main.go#L50) would fail.